### PR TITLE
edit under-bar

### DIFF
--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -19,6 +19,5 @@
               = group.name 
           .group__new-message
             %a.under-line メッセージはまだありません。  
-              = group.name 
-          .group__new-message
-            メッセージはまだありません。
+          
+          


### PR DESCRIPTION
#What 
グループ名のアンダーバーを削除

#Why
不必要な装飾のため、cssを編集